### PR TITLE
Set JVM target to 11 and add .gradle-home ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .kiro
 .idea
 .gradle
+.gradle-home
 .kotlin
 target/
 build/

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -5,9 +8,11 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
-
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
     js(IR) {
         nodejs()
         browser()
@@ -56,4 +61,8 @@ kotlin {
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(11)
 }

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotlin.serialization)
@@ -5,9 +8,11 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
-
-    jvm { withJava() }
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_11)
+        }
+    }
     js(IR) {
         nodejs()
         browser()
@@ -48,4 +53,8 @@ kotlin {
 
 tasks.named<Test>("jvmTest") {
     useJUnitPlatform()
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.release.set(11)
 }


### PR DESCRIPTION
Replace jvmToolchain usage with explicit Kotlin compilerOptions (jvmTarget = JVM_11) in core and stream modules, add JavaCompile configuration to set options.release = 11, and add required imports. Also update .gitignore to ignore .gradle-home. These changes ensure consistent Java/Kotlin bytecode target compatibility across the project (Java 11) and exclude the new gradle home directory from VCS.