### PR TITLE
fix: use query params instead of body params for GET requests

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -25,6 +25,11 @@ jobs:
           project_version=$(./gradlew version --no-daemon --console=plain -q)
           echo "PROJECT_VERSION=$project_version" >> $GITHUB_ENV
 
+      - name: Copy Docs to Npm Package
+        run: |
+          cp ./docs/js/README.md ./all/build/dist/js/productionLibrary/README.md
+          cp ./docs/js/README_ja.md ./all/build/dist/js/productionLibrary/README_ja.md
+
       - name: Commit Pods to GitHub
         if: github.ref == 'refs/heads/main'
         run: |

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Pods Npm Package
         uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: all:jsBrowserDevelopmentLibraryDistribution -x check --refresh-dependencies
+          arguments: all:jsBrowserProductionLibraryDistribution -x check
 
       - name: Set Project Version
         run: |
@@ -27,6 +27,7 @@ jobs:
 
       - name: Copy Docs to Npm Package
         run: |
+          cp ./LICENSE ./all/build/dist/js/productionLibrary/LICENSE
           cp ./docs/js/README.md ./all/build/dist/js/productionLibrary/README.md
           cp ./docs/js/README_ja.md ./all/build/dist/js/productionLibrary/README_ja.md
 
@@ -35,7 +36,7 @@ jobs:
         run: |
           git config --global user.email "a.urusihara@gmail.com"
           git config --global user.name "Akihiro Urushihara"
-          cd ./all/build/dist/js/developmentLibrary/
+          cd ./all/build/dist/js/productionLibrary/
           git init
           git add --all
           git commit -m "by GitHub Action CI (SHA ${GITHUB_SHA})"

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/AbstractResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/AbstractResourceImpl.kt
@@ -110,17 +110,17 @@ abstract class AbstractResourceImpl(
                 if ((service === Service.PIXELFED) &&
                     (limit > AbstractAuthResourceImpl.PIXELFED_LIMIT_MAX)
                 ) limit = AbstractAuthResourceImpl.PIXELFED_LIMIT_MAX
-                param("limit", limit)
+                query("limit", limit)
             }
 
             // since_id
-            range.sinceId?.let { param("since_id", it) }
+            range.sinceId?.let { query("since_id", it) }
 
             // max_id
-            range.maxId?.let { param("max_id", it) }
+            range.maxId?.let { query("max_id", it) }
 
             // min_id
-            range.minId?.let { param("min_id", it) }
+            range.minId?.let { query("min_id", it) }
         }
 
         return this

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/TimelinesResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/TimelinesResourceImpl.kt
@@ -69,8 +69,8 @@ class TimelinesResourceImpl(
                 .url("${uri}/api/v1/timelines/public")
                 .header(AUTHORIZATION, bearerToken())
                 .accept(MediaType.JSON)
-                .pwn("local", request.local)
-                .pwn("only_media", request.onlyMedia)
+                .qwn("local", request.local)
+                .qwn("only_media", request.onlyMedia)
                 .paging(request.range, service())
                 .get()
         }
@@ -92,8 +92,8 @@ class TimelinesResourceImpl(
                 .url("${uri}/api/v1/timelines/tag/${request.hashtag}")
                 .header(AUTHORIZATION, bearerToken())
                 .accept(MediaType.JSON)
-                .pwn("local", request.local)
-                .pwn("only_media", request.onlyMedia)
+                .qwn("local", request.local)
+                .qwn("only_media", request.onlyMedia)
                 .paging(request.range, service())
                 .get()
         }


### PR DESCRIPTION
Changed `param()` to `query()` in `paging`,
and changed `pwn` to `qwn` in `TimelinesResourceImpl`.
Fixed an issue where GET requests with body parameters caused an `IllegalStateException` in the JS target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination so limit/since/max/min are correctly sent as query parameters.
  * Improved timeline parameter handling for local and media-only filters to ensure accurate filtering.

* **Chores**
  * Updated packaging workflow to produce the production JS browser build and include license/README files in the published package.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uakihir0/kmastodon/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->