### PR TITLE
fix: replace instanceV1Blocking with suspend instanceV1 in stream

### DIFF
--- a/stream/src/commonMain/kotlin/work/socialhub/kmastodon/stream/internal/BaseStreamImpl.kt
+++ b/stream/src/commonMain/kotlin/work/socialhub/kmastodon/stream/internal/BaseStreamImpl.kt
@@ -9,13 +9,13 @@ open class BaseStreamImpl(
 ) {
     var client: StreamClient? = null
 
-    fun createClient(): StreamClient {
+    suspend fun createClient(): StreamClient {
         val queryString = query
             .map { "${it.key}=${it.value}" }
             .joinToString("&")
 
         val streamUrl = MastodonFactory
-            .instance(uri).instances().instanceV1Blocking()
+            .instance(uri).instances().instanceV1()
             .data.urls.streamingApi +
                 "/api/v1/streaming?" +
                 queryString


### PR DESCRIPTION
BaseStreamImpl.createClient() used instanceV1Blocking() which calls toBlocking() that throws UnsupportedOperationException on JS targets. Change createClient() to suspend and call instanceV1() directly.