### PR TITLE
ci: add concurrency to CI workflows

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,4 +1,7 @@
 name: Make Npm Package
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on: [push]
 
 jobs:

--- a/.github/workflows/pods.yml
+++ b/.github/workflows/pods.yml
@@ -1,4 +1,7 @@
 name: Make XCFramework
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on: [push]
 
 jobs:

--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -1,4 +1,7 @@
 name: Publish Package
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on:
   push:
     branches:

--- a/.github/workflows/swiftpackage.yml
+++ b/.github/workflows/swiftpackage.yml
@@ -1,4 +1,7 @@
 name: Make SwiftPackage
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 on: [push]
 
 jobs:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GitHub Actions workflows by adding concurrency controls to prevent duplicate runs and improve CI/CD pipeline efficiency across build and publish processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->