### PR TITLE
Remove deprecated macosX64 target

### DIFF
--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
         iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
-        macosX64(),
         macosArm64(),
     ).forEach {
         it.binaries.framework {

--- a/all/build.gradle.kts
+++ b/all/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 kotlin {
-    js(IR) {
+    js {
         nodejs()
         browser()
         binaries.library()

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,7 +27,6 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
-    macosX64()
     macosArm64()
 
     sourceSets {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
-    js(IR) {
+    js {
         nodejs()
         browser()
         binaries.library()

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ mavenCentralAutomaticPublishing=true
 
 # Java Toolchain Auto-Provisioning
 org.gradle.java.installations.auto-detect=true
-org.gradle.java.installations.auto-download=truekotlin.native.ignoreDisabledTargets=true
+org.gradle.java.installations.auto-download=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@ mavenCentralAutomaticPublishing=true
 
 # Java Toolchain Auto-Provisioning
 org.gradle.java.installations.auto-detect=true
-org.gradle.java.installations.auto-download=true
+org.gradle.java.installations.auto-download=truekotlin.native.ignoreDisabledTargets=true

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
             jvmTarget.set(JvmTarget.JVM_11)
         }
     }
-    js(IR) {
+    js {
         nodejs()
         browser()
         binaries.library()

--- a/stream/build.gradle.kts
+++ b/stream/build.gradle.kts
@@ -22,7 +22,6 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
-    macosX64()
     macosArm64()
 
     sourceSets {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kotlin/JavaScript target configuration
  * Removed Intel macOS support (64-bit)
  * Retained Apple Silicon macOS support
  * Enabled automatic Java toolchain downloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->