### PR TITLE
feat: add bookmark (add) API to BookmarksResource

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/BookmarksResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/BookmarksResource.kt
@@ -1,8 +1,10 @@
 package work.socialhub.kmastodon.api
 
+import work.socialhub.kmastodon.api.request.bookmarks.BookmarksBookmarkRequest
 import work.socialhub.kmastodon.api.request.bookmarks.BookmarksGetBookmarksRequest
 import work.socialhub.kmastodon.api.request.bookmarks.BookmarksUnbookmarkRequest
 import work.socialhub.kmastodon.api.response.Response
+import work.socialhub.kmastodon.api.response.bookmarks.BookmarksBookmarkResponse
 import work.socialhub.kmastodon.api.response.bookmarks.BookmarksGetBookmarksResponse
 import work.socialhub.kmastodon.api.response.bookmarks.BookmarksUnbookmarkResponse
 import kotlin.js.JsExport
@@ -21,6 +23,18 @@ interface BookmarksResource {
     fun bookmarksBlocking(
         request: BookmarksGetBookmarksRequest
     ): Response<Array<BookmarksGetBookmarksResponse>>
+
+    /**
+     * Adding a bookmark.
+     */
+    suspend fun bookmark(
+        request: BookmarksBookmarkRequest
+    ): Response<BookmarksBookmarkResponse>
+
+    @JsExport.Ignore
+    fun bookmarkBlocking(
+        request: BookmarksBookmarkRequest
+    ): Response<BookmarksBookmarkResponse>
 
     /**
      * Removing a bookmark.

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/request/bookmarks/BookmarksBookmarkRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/request/bookmarks/BookmarksBookmarkRequest.kt
@@ -1,0 +1,8 @@
+package work.socialhub.kmastodon.api.request.bookmarks
+
+import kotlin.js.JsExport
+
+@JsExport
+class BookmarksBookmarkRequest {
+    var id: String? = null
+}

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/response/bookmarks/BookmarksBookmarkResponse.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/response/bookmarks/BookmarksBookmarkResponse.kt
@@ -1,0 +1,5 @@
+package work.socialhub.kmastodon.api.response.bookmarks
+
+import work.socialhub.kmastodon.entity.Status
+
+typealias BookmarksBookmarkResponse = Status

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/BookmarksResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/BookmarksResourceImpl.kt
@@ -2,9 +2,11 @@ package work.socialhub.kmastodon.internal
 
 import work.socialhub.khttpclient.HttpRequest
 import work.socialhub.kmastodon.api.BookmarksResource
+import work.socialhub.kmastodon.api.request.bookmarks.BookmarksBookmarkRequest
 import work.socialhub.kmastodon.api.request.bookmarks.BookmarksGetBookmarksRequest
 import work.socialhub.kmastodon.api.request.bookmarks.BookmarksUnbookmarkRequest
 import work.socialhub.kmastodon.api.response.Response
+import work.socialhub.kmastodon.api.response.bookmarks.BookmarksBookmarkResponse
 import work.socialhub.kmastodon.api.response.bookmarks.BookmarksGetBookmarksResponse
 import work.socialhub.kmastodon.api.response.bookmarks.BookmarksUnbookmarkResponse
 import work.socialhub.kmastodon.domain.Service
@@ -36,6 +38,26 @@ class BookmarksResourceImpl(
     ): Response<Array<BookmarksGetBookmarksResponse>> {
         return toBlocking {
             bookmarks(request)
+        }
+    }
+
+    override suspend fun bookmark(
+        request: BookmarksBookmarkRequest
+    ): Response<BookmarksBookmarkResponse> {
+        return proceed {
+            HttpRequest()
+                .url("${uri}/api/v1/statuses/${request.id}/bookmark")
+                .header(AUTHORIZATION, bearerToken())
+                .accept(MediaType.JSON)
+                .post()
+        }
+    }
+
+    override fun bookmarkBlocking(
+        request: BookmarksBookmarkRequest
+    ): Response<BookmarksBookmarkResponse> {
+        return toBlocking {
+            bookmark(request)
         }
     }
 

--- a/core/src/jvmTest/kotlin/work/socialhub/kmastodon/apis/BookmarksTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmastodon/apis/BookmarksTest.kt
@@ -2,11 +2,14 @@ package work.socialhub.kmastodon.apis
 
 import kotlinx.coroutines.test.runTest
 import work.socialhub.kmastodon.AbstractTest
+import work.socialhub.kmastodon.api.request.bookmarks.BookmarksBookmarkRequest
 import work.socialhub.kmastodon.api.request.bookmarks.BookmarksGetBookmarksRequest
 import work.socialhub.kmastodon.api.request.bookmarks.BookmarksUnbookmarkRequest
-import kotlin.test.Ignore
+import work.socialhub.kmastodon.api.request.statuses.StatusesDeleteStatusRequest
+import work.socialhub.kmastodon.api.request.statuses.StatusesPostStatusRequest
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class BookmarksTest : AbstractTest() {
 
@@ -19,12 +22,33 @@ class BookmarksTest : AbstractTest() {
     }
 
     @Test
-    @Ignore("Requires a bookmarked status on the test account")
-    fun testUnbookmark() = runTest {
-        mastodon().bookmarks().unbookmark(
-            BookmarksUnbookmarkRequest().also {
-                it.id = "REQUIRED_STATUS_ID"
+    fun testBookmarkAndUnbookmark() = runTest {
+        val created = mastodon().statuses().postStatus(
+            StatusesPostStatusRequest().also {
+                it.status = "Bookmark test from kmastodon BookmarksTest"
             }
         )
+        assertNotNull(created.data.id)
+        val statusId = created.data.id
+
+        try {
+            val bookmarked = mastodon().bookmarks().bookmark(
+                BookmarksBookmarkRequest().also { it.id = statusId }
+            )
+            assertNotNull(bookmarked.data)
+            assertTrue(bookmarked.data.isBookmarked)
+            println("Bookmarked status: $statusId")
+
+            val unbookmarked = mastodon().bookmarks().unbookmark(
+                BookmarksUnbookmarkRequest().also { it.id = statusId }
+            )
+            assertNotNull(unbookmarked.data)
+            println("Unbookmarked status: $statusId")
+        } finally {
+            mastodon().statuses().deleteStatus(
+                StatusesDeleteStatusRequest().also { it.id = statusId }
+            )
+            println("Deleted status: $statusId")
+        }
     }
 }


### PR DESCRIPTION
Add POST /api/v1/statuses/:id/bookmark endpoint support:
- BookmarksBookmarkRequest/Response
- BookmarksResource.bookmark/bookmarkBlocking
- BookmarksResourceImpl implementation
- Integration test: testBookmarkAndUnbookmark (create → bookmark → unbookmark → delete)