### PR TITLE
ci: simplify SNAPSHOT publish to a single unscoped publish

### DIFF
--- a/.github/workflows/snapshot-publish.yml
+++ b/.github/workflows/snapshot-publish.yml
@@ -11,12 +11,6 @@ jobs:
   build:
     runs-on: macos-latest
 
-    strategy:
-      matrix:
-        target:
-          - core
-          - stream
-
     permissions:
       contents: read
       packages: write
@@ -29,15 +23,11 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: Build with Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: ${{ matrix.target }}:build -x ${{ matrix.target }}:jvmTest --refresh-dependencies
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Publish to Repsy
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: ${{ matrix.target }}:publishAllPublicationsToMavenRepository -x ${{ matrix.target }}:jvmTest --refresh-dependencies
+        run: ./gradlew publishAllPublicationsToMavenRepository -x check
         env:
           USERNAME: ${{ secrets.REPSY_USERNAME }}
           PASSWORD: ${{ secrets.REPSY_PASSWORD }}


### PR DESCRIPTION
Drop the per-target build/publish matrix and the redundant build step. A single unscoped publishAllPublicationsToMavenRepository covers all modules (matching the release workflow) and only emits klibs, so no expensive native framework linking runs. Also modernize to setup-gradle@v4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to streamline the publishing process and upgrade build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->