### PR TITLE
feat: support scheduled_at when posting a status

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/request/statuses/StatusesPostStatusRequest.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/request/statuses/StatusesPostStatusRequest.kt
@@ -16,4 +16,7 @@ class StatusesPostStatusRequest {
     var pollExpiresIn: Int? = null
     var pollMultiple: Boolean? = null
     var pollHideTotals: Boolean? = null
+
+    /** ISO-8601 datetime to schedule the status; must be at least 5 minutes in the future. */
+    var scheduledAt: String? = null
 }

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/StatusesResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/StatusesResourceImpl.kt
@@ -163,6 +163,8 @@ class StatusesResourceImpl(
                 .pwn("poll[expires_in]", request.pollExpiresIn)
                 .pwn("poll[multiple]", request.pollMultiple)
                 .pwn("poll[hide_totals]", request.pollHideTotals)
+
+                .pwn("scheduled_at", request.scheduledAt)
                 .post()
         }
     }


### PR DESCRIPTION
Adds a scheduledAt field to StatusesPostStatusRequest and serializes it as scheduled_at so callers can create scheduled statuses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scheduling status posts in advance.
  * Status creation requests can now include a future date and time for publishing.

* **Bug Fixes**
  * Status posts now correctly send the scheduled publish time when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->