### PR TITLE
Feat/add owned lists

### DIFF
--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/ListsResource.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/api/ListsResource.kt
@@ -21,6 +21,14 @@ import kotlin.js.JsExport
 interface ListsResource {
 
     /**
+     * Fetching the authenticated user's lists.
+     */
+    suspend fun ownedLists(): Response<Array<ListsListsResponse>>
+
+    @JsExport.Ignore
+    fun ownedListsBlocking(): Response<Array<ListsListsResponse>>
+
+    /**
      * Fetching the user's lists that a given account is part of.
      */
     suspend fun lists(

--- a/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/ListsResourceImpl.kt
+++ b/core/src/commonMain/kotlin/work/socialhub/kmastodon/internal/ListsResourceImpl.kt
@@ -30,6 +30,25 @@ class ListsResourceImpl(
     /**
      * {@inheritDoc}
      */
+    override suspend fun ownedLists(): Response<Array<ListsListsResponse>> {
+        return proceed {
+            HttpRequest()
+                .url("${uri}/api/v1/lists")
+                .header(AUTHORIZATION, bearerToken())
+                .accept(MediaType.JSON)
+                .get()
+        }
+    }
+
+    override fun ownedListsBlocking(): Response<Array<ListsListsResponse>> {
+        return toBlocking {
+            ownedLists()
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     override suspend fun lists(
         request: ListsListsRequest
     ): Response<Array<ListsListsResponse>> {

--- a/core/src/jvmTest/kotlin/work/socialhub/kmastodon/apis/ListsEndpointTest.kt
+++ b/core/src/jvmTest/kotlin/work/socialhub/kmastodon/apis/ListsEndpointTest.kt
@@ -1,0 +1,50 @@
+package work.socialhub.kmastodon.apis
+
+import com.sun.net.httpserver.HttpServer
+import java.net.InetSocketAddress
+import kotlinx.coroutines.test.runTest
+import work.socialhub.kmastodon.MastodonFactory
+import work.socialhub.kmastodon.api.request.lists.ListsListsRequest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ListsEndpointTest {
+
+    @Test
+    fun differentiatesOwnedAndContainingAccountLists() = runTest {
+        val requestedPaths = mutableListOf<String>()
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/") { exchange ->
+            requestedPaths.add(exchange.requestURI.path)
+            val body = """[{"id":"list-id","title":"List"}]""".encodeToByteArray()
+            exchange.responseHeaders.add("Content-Type", "application/json")
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+        server.start()
+
+        try {
+            val lists = MastodonFactory.instance(
+                "http://127.0.0.1:${server.address.port}",
+                "access-token",
+            ).lists()
+
+            assertEquals("list-id", lists.ownedLists().data.single().id)
+            assertEquals(
+                "list-id",
+                lists.lists(
+                    ListsListsRequest().also { it.id = "account-id" }
+                ).data.single().id,
+            )
+            assertEquals(
+                listOf(
+                    "/api/v1/lists",
+                    "/api/v1/accounts/account-id/lists",
+                ),
+                requestedPaths,
+            )
+        } finally {
+            server.stop(0)
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving the authenticated account’s lists.
  * Available through both asynchronous and blocking API methods.

* **Tests**
  * Added endpoint coverage verifying owned-list retrieval and existing account-list requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->